### PR TITLE
Fix silent exception swallowing in WHO scraper

### DIFF
--- a/app/lib/scrapers/who/disease_parser.rb
+++ b/app/lib/scrapers/who/disease_parser.rb
@@ -18,11 +18,10 @@ module Scrapers
 
         disease_page.css('h2').each_with_index do |tag, index|
           CORE_ATTR.each do |attr|
-            begin
-              collect_data_for(attr, disease_data, tag, index)
-            rescue
-              next
-            end
+            collect_data_for(attr, disease_data, tag, index)
+          rescue StandardError => e
+            Rails.logger.warn("[WHO DiseaseParser] Failed to parse '#{attr}' for #{disease_data[:name]}: #{e.message}")
+            next
           end
         end
         disease_data

--- a/app/lib/scrapers/who/parser.rb
+++ b/app/lib/scrapers/who/parser.rb
@@ -9,17 +9,34 @@ module Scrapers
       end
 
       def perform
-        disease_list_pages.map do |link|
-          begin
-            disease_data = Scrapers::Who::DiseaseParser.new(link).data
-            Disease.create(disease_data)
-          rescue
-            next
-          end
+        successes = 0
+        failures = []
+
+        disease_list_pages.each do |link|
+          disease_data = Scrapers::Who::DiseaseParser.new(link).data
+          Disease.create!(disease_data)
+          successes += 1
+        rescue StandardError => e
+          href = link.is_a?(String) ? link : link.attributes['href']&.value
+          Rails.logger.error("[WHO Scraper] Failed to scrape #{href}: #{e.message}")
+          failures << { link: href, error: e.message }
+          next
         end
+
+        log_summary(successes, failures)
+        { successes: successes, failures: failures }
       end
 
       private
+
+      def log_summary(successes, failures)
+        total = successes + failures.size
+        Rails.logger.info("[WHO Scraper] Completed: #{successes}/#{total} diseases scraped successfully")
+        return if failures.empty?
+
+        Rails.logger.warn("[WHO Scraper] #{failures.size} disease(s) failed:")
+        failures.each { |f| Rails.logger.warn("  - #{f[:link]}: #{f[:error]}") }
+      end
 
       def disease_list_pages
         @disease_list_pages ||= Nokogiri::HTML(results).css("a[href*='/news-room/fact-sheets/detail/']")

--- a/spec/lib/scrapers/who/disease_parser_spec.rb
+++ b/spec/lib/scrapers/who/disease_parser_spec.rb
@@ -1,35 +1,82 @@
 require 'rails_helper'
 
 describe Scrapers::Who::DiseaseParser do
-  let(:fetch_disease_link) do
-    VCR.use_cassette('who/scrapers/fetch_disease_link') do
-      url = 'http://www.who.int/topics/infectious_diseases/factsheets/en/'
-      request = Scrapers::Who::Request.new(url)
-      Nokogiri::HTML(request.response.results).css(".auto_archive>li>a").first
-    end
+  let(:disease_html) do
+    <<~HTML
+      <html>
+        <head>
+          <meta name="date" content="March 2016">
+        </head>
+        <body>
+          <h1>Lassa fever</h1>
+          <div>
+            <h2>Key facts</h2>
+          </div>
+          <div>
+            <ul>
+              <li>Fact one</li>
+              <li>Fact two</li>
+            </ul>
+          </div>
+          <h2>Symptoms</h2>
+          <p>Fever and headache</p>
+          <h2>Transmission</h2>
+          <p>Contact with rodents</p>
+          <h2>Diagnosis</h2>
+          <p>Lab testing</p>
+          <h2>Treatment</h2>
+          <p>Supportive care</p>
+          <h2>Prevention</h2>
+          <p>Avoid rodent contact</p>
+        </body>
+      </html>
+    HTML
   end
 
-  let(:disease_link) { fetch_disease_link }
+  let(:disease_link) { '/news-room/fact-sheets/detail/lassa-fever' }
   let(:parser) { described_class.new(disease_link) }
-  let(:parsed_data) {}
   let(:keys) do
     [:name, :date_updated, :facts, :more, :symptoms, :transmission, :diagnosis,
       :treatment, :prevention]
   end
 
+  before do
+    mock_response = instance_double(Scrapers::Who::Response, results: disease_html)
+    mock_request = instance_double(Scrapers::Who::Request, response: mock_response)
+    allow(Scrapers::Who::Request).to receive(:new).and_return(mock_request)
+  end
+
   describe '#data' do
     it 'returns the parsed data' do
-      VCR.use_cassette('who/scrapers/parsed_data') do
-        expect(parser.data.keys).to eq(keys)
-      end
+      data = parser.data
+      expect(data.keys).to eq(keys)
+    end
+
+    it 'parses disease name with source suffix' do
+      data = parser.data
+      expect(data[:name]).to eq('Lassa fever - WHO')
+    end
+
+    it 'parses core attributes from HTML' do
+      data = parser.data
+      expect(data[:symptoms]).to include('Fever and headache')
+      expect(data[:transmission]).to include('Contact with rodents')
     end
 
     describe 'when parsed data has invalid data' do
+      before do
+        allow_any_instance_of(described_class).to receive(:collect_data_for).and_raise(StandardError, "bad html")
+      end
+
       it 'does not return any error' do
-        VCR.use_cassette('who/scrapers/parsed_data') do
-          allow_any_instance_of(described_class).to receive(:collect_data_for).and_raise("this error")
-          expect { parser.data }.to_not raise_error
-        end
+        expect { parser.data }.to_not raise_error
+      end
+
+      it 'logs a warning for the failed attribute' do
+        expect(Rails.logger).to receive(:warn)
+          .with(/\[WHO DiseaseParser\] Failed to parse/).at_least(:once)
+
+        parser.data
       end
     end
   end

--- a/spec/lib/scrapers/who/parser_spec.rb
+++ b/spec/lib/scrapers/who/parser_spec.rb
@@ -6,7 +6,7 @@ describe Scrapers::Who::Parser do
       :name=> "Lassa fever - WHO",
       :date_updated=> "March 2016",
       :facts=> ["facts test"],
-      :more=>"Source is http://www.who.int/entity/mediacentre/factsheets/fs179/en/index.html",
+      :more=>"Source is https://www.who.int/news-room/fact-sheets/detail/lassa-fever",
       :symptoms=> "test",
       :transmission=> "test",
       :diagnosis=> "test",
@@ -15,52 +15,74 @@ describe Scrapers::Who::Parser do
      }
   end
 
+  let(:fake_links) do
+    html = '<a href="/news-room/fact-sheets/detail/lassa-fever">Lassa fever</a>
+            <a href="/news-room/fact-sheets/detail/cholera">Cholera</a>'
+    Nokogiri::HTML(html).css('a')
+  end
+
+  before do
+    allow_any_instance_of(described_class).to receive(:disease_list_pages).and_return(fake_links)
+  end
+
   describe '.perform' do
-    context 'with valida data' do
+    context 'with valid data' do
+      before do
+        allow_any_instance_of(Scrapers::Who::DiseaseParser)
+          .to receive(:data).and_return(disease_data)
+      end
+
       it 'delegates to #perform on an instance with the given arguments' do
         instance = double(perform: :performed)
-        expect(described_class).to receive(:new) { instance }
+        allow(described_class).to receive(:new).and_return(instance)
         expect(described_class.perform).to eq :performed
       end
 
       it 'should save gotten disease to the database' do
-        VCR.use_cassette('who/scrapers/parser') do
-          allow_any_instance_of(Scrapers::Who::DiseaseParser)
-            .to receive(:data).and_return(disease_data)
-
-          expect { described_class.perform }.to change { Disease.count }
-        end
+        expect { described_class.perform }.to change { Disease.count }.by(2)
       end
 
       it 'saves the disease with the expected attributes' do
-        VCR.use_cassette('who/scrapers/parser') do
-          allow_any_instance_of(Scrapers::Who::DiseaseParser)
-            .to receive(:data).and_return(disease_data)
+        described_class.perform
+        disease = Disease.first
 
-          described_class.perform
-          disease = Disease.first
-
-          expect(disease.name).to eq(disease_data[:name])
-          expect(disease.date_updated).to eq(disease_data[:date_updated])
-          expect(disease.facts).to eq(disease_data[:facts])
-          expect(disease.more).to eq(disease_data[:more])
-          expect(disease.symptoms).to eq(disease_data[:symptoms])
-          expect(disease.transmission).to eq(disease_data[:transmission])
-          expect(disease.diagnosis).to eq(disease_data[:diagnosis])
-          expect(disease.treatment).to eq(disease_data[:treatment])
-          expect(disease.prevention).to eq(disease_data[:prevention])
-        end
+        expect(disease.name).to eq(disease_data[:name])
+        expect(disease.date_updated).to eq(disease_data[:date_updated])
+        expect(disease.facts).to eq(disease_data[:facts])
+        expect(disease.more).to eq(disease_data[:more])
+        expect(disease.symptoms).to eq(disease_data[:symptoms])
+        expect(disease.transmission).to eq(disease_data[:transmission])
+        expect(disease.diagnosis).to eq(disease_data[:diagnosis])
+        expect(disease.treatment).to eq(disease_data[:treatment])
+        expect(disease.prevention).to eq(disease_data[:prevention])
       end
     end
 
     describe 'when got an error' do
-      it 'does not raise any error' do
-        VCR.use_cassette('who/scrapers/parser') do
-          allow_any_instance_of(Scrapers::Who::DiseaseParser)
-            .to receive(:data).and_raise("this error")
+      before do
+        allow(Rails.logger).to receive(:error)
+        allow(Rails.logger).to receive(:info)
+        allow(Rails.logger).to receive(:warn)
+        allow_any_instance_of(Scrapers::Who::DiseaseParser)
+          .to receive(:data).and_raise(StandardError, "parse failed")
+      end
 
-          expect { described_class.perform }.to_not raise_error
-        end
+      it 'does not raise any error' do
+        expect { described_class.perform }.to_not raise_error
+      end
+
+      it 'logs the error for each failed disease' do
+        expect(Rails.logger).to receive(:error)
+          .with(/\[WHO Scraper\] Failed to scrape/).at_least(:once)
+
+        described_class.perform
+      end
+
+      it 'returns a summary with failure details' do
+        result = described_class.perform
+        expect(result[:successes]).to eq(0)
+        expect(result[:failures].size).to eq(2)
+        expect(result[:failures].first).to include(:link, :error)
       end
     end
   end


### PR DESCRIPTION
## Summary
- Replaces bare `rescue` blocks in `Parser` and `DiseaseParser` with `rescue StandardError => e` so errors are logged instead of silently swallowed (fixes #40)
- `Parser#perform` now uses `Disease.create!` and returns a `{ successes:, failures: }` summary hash with per-disease error details
- `DiseaseParser#data` logs warnings for individual attribute parsing failures
- Rewrites scraper specs to use stubs instead of stale VCR cassettes that referenced old WHO URLs

## Test plan
- [x] All 11 scraper tests pass (`bundle exec rspec spec/lib/scrapers/who/`)
- [x] Full test suite passes (1 pre-existing unrelated failure in `DiseasesController`)
- [x] Run `rake mine_data:who` against live WHO site to verify logging output

🤖 Generated with [Claude Code](https://claude.com/claude-code)