### PR TITLE
Convert disease text fields to structured arrays

### DIFF
--- a/app/lib/scrapers/who/disease_parser.rb
+++ b/app/lib/scrapers/who/disease_parser.rb
@@ -37,7 +37,7 @@ module Scrapers
           else
             xpath_text = "//h2[contains(text(),'#{tag.text}')]/following::p"
           end
-          attr_text = disease_page.xpath(xpath_text).map { |p| p.text.strip }.reject(&:empty?)
+          attr_text = disease_page.xpath(xpath_text).map { |p| p.text.strip }.reject(&:blank?)
           disease_data[core_attribute.to_sym] = attr_text
         end
       end

--- a/app/lib/scrapers/who/disease_parser.rb
+++ b/app/lib/scrapers/who/disease_parser.rb
@@ -37,7 +37,7 @@ module Scrapers
           else
             xpath_text = "//h2[contains(text(),'#{tag.text}')]/following::p"
           end
-          attr_text = disease_page.xpath(xpath_text).text
+          attr_text = disease_page.xpath(xpath_text).map { |p| p.text.strip }.reject(&:empty?)
           disease_data[core_attribute.to_sym] = attr_text
         end
       end

--- a/app/models/disease.rb
+++ b/app/models/disease.rb
@@ -2,6 +2,11 @@ class Disease < ActiveRecord::Base
   validates_presence_of :name
 
   serialize :facts, type: Array
+  serialize :symptoms, type: Array
+  serialize :transmission, type: Array
+  serialize :diagnosis, type: Array
+  serialize :treatment, type: Array
+  serialize :prevention, type: Array
 
   scope :active, -> { where(is_active: true) }
   scope :inactive, -> { where(is_active: false) }

--- a/db/migrate/20260322000000_convert_disease_fields_to_arrays.rb
+++ b/db/migrate/20260322000000_convert_disease_fields_to_arrays.rb
@@ -1,0 +1,29 @@
+class ConvertDiseaseFieldsToArrays < ActiveRecord::Migration[7.1]
+  FIELDS = %i[symptoms transmission diagnosis treatment prevention].freeze
+
+  def up
+    Disease.find_each do |disease|
+      updates = {}
+      FIELDS.each do |field|
+        value = disease.read_attribute_before_type_cast(field)
+        next if value.blank? || value.start_with?("---")
+
+        updates[field] = [value]
+      end
+      disease.update_columns(updates) if updates.any?
+    end
+  end
+
+  def down
+    Disease.find_each do |disease|
+      updates = {}
+      FIELDS.each do |field|
+        value = disease.send(field)
+        next unless value.is_a?(Array)
+
+        updates[field] = value.join("\n\n")
+      end
+      disease.update_columns(updates) if updates.any?
+    end
+  end
+end

--- a/db/migrate/20260322000000_convert_disease_fields_to_arrays.rb
+++ b/db/migrate/20260322000000_convert_disease_fields_to_arrays.rb
@@ -1,29 +1,39 @@
 class ConvertDiseaseFieldsToArrays < ActiveRecord::Migration[7.1]
-  FIELDS = %i[symptoms transmission diagnosis treatment prevention].freeze
+  FIELDS = %w[symptoms transmission diagnosis treatment prevention].freeze
 
   def up
-    Disease.find_each do |disease|
-      updates = {}
+    rows = execute("SELECT id, #{FIELDS.join(', ')} FROM diseases")
+    rows.each do |row|
+      sets = []
       FIELDS.each do |field|
-        value = disease.read_attribute_before_type_cast(field)
+        value = row[field]
         next if value.blank? || value.start_with?("---")
 
-        updates[field] = [value]
+        yaml = YAML.dump([value])
+        sets << "#{field} = #{connection.quote(yaml)}"
       end
-      disease.update_columns(updates) if updates.any?
+      execute("UPDATE diseases SET #{sets.join(', ')} WHERE id = #{row['id']}") if sets.any?
     end
   end
 
   def down
-    Disease.find_each do |disease|
-      updates = {}
+    rows = execute("SELECT id, #{FIELDS.join(', ')} FROM diseases")
+    rows.each do |row|
+      sets = []
       FIELDS.each do |field|
-        value = disease.send(field)
-        next unless value.is_a?(Array)
+        value = row[field]
+        next if value.blank?
 
-        updates[field] = value.join("\n\n")
+        parsed = begin
+          YAML.safe_load(value, permitted_classes: [Symbol])
+        rescue StandardError
+          nil
+        end
+        next unless parsed.is_a?(Array)
+
+        sets << "#{field} = #{connection.quote(parsed.join("\n\n"))}"
       end
-      disease.update_columns(updates) if updates.any?
+      execute("UPDATE diseases SET #{sets.join(', ')} WHERE id = #{row['id']}") if sets.any?
     end
   end
 end

--- a/spec/factories/disease.rb
+++ b/spec/factories/disease.rb
@@ -2,11 +2,11 @@ FactoryBot.define do
   factory :disease do
     name { Faker::Lorem.word }
     facts { [Faker::Lorem.sentence] }
-    symptoms { Faker::Lorem.paragraph }
-    transmission { Faker::Lorem.paragraph }
-    diagnosis { Faker::Lorem.paragraph }
-    treatment { Faker::Lorem.paragraph }
-    prevention { Faker::Lorem.paragraph }
+    symptoms { [Faker::Lorem.sentence, Faker::Lorem.sentence] }
+    transmission { [Faker::Lorem.sentence, Faker::Lorem.sentence] }
+    diagnosis { [Faker::Lorem.sentence, Faker::Lorem.sentence] }
+    treatment { [Faker::Lorem.sentence, Faker::Lorem.sentence] }
+    prevention { [Faker::Lorem.sentence, Faker::Lorem.sentence] }
     more { Faker::Lorem.paragraph }
   end
 end

--- a/spec/lib/scrapers/who/disease_parser_spec.rb
+++ b/spec/lib/scrapers/who/disease_parser_spec.rb
@@ -66,6 +66,29 @@ describe Scrapers::Who::DiseaseParser do
       expect(data[:prevention]).to eq(['Avoid rodent contact'])
     end
 
+    context 'with multiple paragraphs per section' do
+      let(:disease_html) do
+        <<~HTML
+          <html>
+            <head><meta name="date" content="March 2016"></head>
+            <body>
+              <h1>Test disease</h1>
+              <h2>Symptoms</h2>
+              <p>First symptom</p>
+              <p>Second symptom</p>
+              <h2>Transmission</h2>
+              <p>Airborne</p>
+            </body>
+          </html>
+        HTML
+      end
+
+      it 'returns each paragraph as a separate array element' do
+        data = parser.data
+        expect(data[:symptoms]).to eq(['First symptom', 'Second symptom'])
+      end
+    end
+
     describe 'when parsed data has invalid data' do
       before do
         allow_any_instance_of(described_class).to receive(:collect_data_for).and_raise(StandardError, "bad html")

--- a/spec/lib/scrapers/who/disease_parser_spec.rb
+++ b/spec/lib/scrapers/who/disease_parser_spec.rb
@@ -57,10 +57,13 @@ describe Scrapers::Who::DiseaseParser do
       expect(data[:name]).to eq('Lassa fever - WHO')
     end
 
-    it 'parses core attributes from HTML' do
+    it 'parses core attributes from HTML as arrays' do
       data = parser.data
-      expect(data[:symptoms]).to include('Fever and headache')
-      expect(data[:transmission]).to include('Contact with rodents')
+      expect(data[:symptoms]).to eq(['Fever and headache'])
+      expect(data[:transmission]).to eq(['Contact with rodents'])
+      expect(data[:diagnosis]).to eq(['Lab testing'])
+      expect(data[:treatment]).to eq(['Supportive care'])
+      expect(data[:prevention]).to eq(['Avoid rodent contact'])
     end
 
     describe 'when parsed data has invalid data' do


### PR DESCRIPTION
## Summary
- Serializes `symptoms`, `transmission`, `diagnosis`, `treatment`, and `prevention` as arrays in the Disease model, matching the existing `facts` field pattern
- Updates the WHO scraper to collect each `<p>` tag as a separate array element instead of concatenating into a single string
- Adds a reversible data migration to convert existing plain-text values into single-element arrays

Closes #64

## Test plan
- [x] All existing model and parser specs pass
- [ ] Verify API responses return arrays for the converted fields
- [ ] Run `rake db:migrate` on staging to confirm data migration works on real data

🤖 Generated with [Claude Code](https://claude.com/claude-code)