### PR TITLE
Fix set_active_status matching wrong disease

### DIFF
--- a/app/controllers/diseases_controller.rb
+++ b/app/controllers/diseases_controller.rb
@@ -1,5 +1,6 @@
 class DiseasesController < ApplicationController
-  before_action :set_disease, only: [:show, :set_active_status]
+  before_action :set_disease, only: [:show]
+  before_action :set_disease_exact, only: [:set_active_status]
 
   def index
     if permitted_params.include?(:data_source)
@@ -31,6 +32,10 @@ class DiseasesController < ApplicationController
   private
   def set_disease
     @disease = Disease.where("lower(name) LIKE ?", "%#{Disease.sanitize_sql_like(permitted_params[:disease].downcase)}%").first
+  end
+
+  def set_disease_exact
+    @disease = Disease.find_by("lower(name) = ?", permitted_params[:disease].downcase)
   end
 
   def permitted_params


### PR DESCRIPTION
## Summary
- `set_active_status` shared the `set_disease` callback which uses a `LIKE '%name%'` query with `.first`, causing it to potentially update the wrong disease when multiple diseases have overlapping names
- Added a separate `set_disease_exact` callback for `set_active_status` that uses exact name matching (`=`), which is the correct semantics for a mutation endpoint

## Test plan
- [x] Full test suite passes (31 examples, 0 failures) — previously had 1 failure in `PUT#set_active_status should update disease to active when given a truthy value`

🤖 Generated with [Claude Code](https://claude.com/claude-code)