### PR TITLE
Add Render.com deployment config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'nokogiri', '>= 1.19.1'
 gem 'rack-cors', :require => 'rack/cors'
 gem 'jbuilder', '~> 2.11'
 gem 'responders', '~> 3.0'
+gem 'puma'
 
 group :development, :test do
   gem 'pry'
@@ -30,7 +31,6 @@ end
 group :development do
   gem 'web-console', '>= 4.1.0'
   gem 'spring'
-  gem 'puma'
 end
 
 group :production do

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: bundle exec puma -C config/puma.rb -p ${PORT:-3000}
+release: bundle exec rake db:migrate

--- a/config/database.yml
+++ b/config/database.yml
@@ -48,7 +48,7 @@ test:
 #     url: <%= ENV['DATABASE_URL'] %>
 #
 production:
-  <<: *default
-  database: disease-info_production
-  username: disease-info
-  password: <%= ENV['DISEASE-INFO_DATABASE_PASSWORD'] %>
+  adapter: postgresql
+  encoding: unicode
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  url: <%= ENV['DATABASE_URL'] %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -26,7 +26,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :terser
+  # config.assets.js_compressor = :terser
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
@@ -74,6 +74,12 @@ Rails.application.configure do
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
+
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    logger = ActiveSupport::Logger.new(STDOUT)
+    logger.formatter = config.log_formatter
+    config.logger = ActiveSupport::TaggedLogging.new(logger)
+  end
 
   # Do not dump schema after migrations
   config.active_record.dump_schema_after_migration = false

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,11 @@
+max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
+min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
+threads min_threads_count, max_threads_count
+
+port ENV.fetch("PORT") { 3000 }
+
+environment ENV.fetch("RAILS_ENV") { "development" }
+
+workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+
+preload_app!

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,25 @@
+databases:
+  - name: disease-info-db
+    databaseName: disease_info_production
+    user: disease_info
+    plan: free
+
+services:
+  - type: web
+    name: disease-info-api
+    runtime: ruby
+    buildCommand: bundle install && bundle exec rake db:migrate
+    startCommand: bundle exec puma -C config/puma.rb
+    envVars:
+      - key: DATABASE_URL
+        fromDatabase:
+          name: disease-info-db
+          property: connectionString
+      - key: SECRET_KEY_BASE
+        generateValue: true
+      - key: RAILS_ENV
+        value: production
+      - key: RAILS_SERVE_STATIC_FILES
+        value: "true"
+      - key: RAILS_LOG_TO_STDOUT
+        value: "true"


### PR DESCRIPTION
## Summary
- Move `puma` gem to top-level so it's available as the production web server
- Add `Procfile` and `config/puma.rb` for Puma configuration
- Update production `database.yml` to use `DATABASE_URL` env var (replaces hardcoded Heroku-style config)
- Add STDOUT logging and disable unused `terser` JS compressor in production config
- Add `render.yaml` Blueprint for one-click Render.com deploy

## Test plan
- [ ] `bundle install` succeeds locally
- [ ] `rails server` starts without errors locally
- [ ] Deploy to Render.com via Blueprint or manual setup
- [ ] Run `bundle exec rake mine_data:all` via Render Shell to populate data
- [ ] Verify `GET /diseases` returns JSON
- [ ] Verify `GET /diseases/:disease` returns single disease
- [ ] Verify CORS headers present in responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)