### PR TITLE
Add x86_64-linux platform to Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,7 +156,10 @@ GEM
     nio4r (2.7.5)
     nokogiri (1.19.2-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.19.2-x86_64-linux-gnu)
+      racc (~> 1.4)
     pg (1.6.3-arm64-darwin)
+    pg (1.6.3-x86_64-linux)
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
@@ -287,6 +290,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-25
+  x86_64-linux
 
 DEPENDENCIES
   database_cleaner-active_record


### PR DESCRIPTION
## Summary
- Adds the `x86_64-linux` platform to `Gemfile.lock` so Bundler works on Render's Linux servers
- Without this, the deploy fails because the lockfile only had `arm64-darwin-25` (macOS)

## Test plan
- [ ] Render deploy succeeds past the `bundle install` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)