### PR TITLE
Fix config.assets error for API-only deploy

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,11 +30,11 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  # config.assets.compile = false
 
   # Asset digests allow you to set far-future HTTP expiration dates on all assets,
   # yet still be able to expire them through the digest params.
-  config.assets.digest = true
+  # config.assets.digest = true
 
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 


### PR DESCRIPTION
## Summary
- Comment out `config.assets.compile` and `config.assets.digest` in production.rb
- This app is API-only (no sprockets/asset pipeline), so these calls cause `undefined method 'assets'` errors on deploy

## Test plan
- [ ] Render deploy passes the `db:migrate` step without crashing
- [ ] API starts and responds to requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)