### PR TITLE
Remove sprockets for API-only Render deploy

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,15 @@
 require File.expand_path('../boot', __FILE__)
 
-require 'rails/all'
+require "active_record/railtie"
+require "active_storage/engine"
+require "action_controller/railtie"
+require "action_mailer/railtie"
+require "action_mailbox/engine"
+require "action_text/engine"
+require "action_view/railtie"
+require "action_cable/engine"
+require "rails/test_unit/railtie"
+# require "sprockets/railtie" # Not needed for API-only app
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.


### PR DESCRIPTION
## Summary
- Replace `require 'rails/all'` with individual railtie requires, excluding `sprockets/railtie`
- Comment out `config.assets` references in production.rb
- This app is API-only with no asset pipeline — sprockets was causing `undefined method 'assets'` errors on deploy

## Test plan
- [ ] Render deploy passes `bundle install && bundle exec rake db:migrate`
- [ ] API starts and responds to `GET /diseases`

🤖 Generated with [Claude Code](https://claude.com/claude-code)