### PR TITLE
Fix jbuilder config error breaking deploy

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,5 +83,5 @@ Rails.application.configure do
 
   # Do not dump schema after migrations
   config.active_record.dump_schema_after_migration = false
-  config.jbuilder.prettify = true
+  Jbuilder.prettify = true if defined?(Jbuilder)
 end


### PR DESCRIPTION
## Summary
- `config.jbuilder.prettify = true` in production.rb crashes with `NoMethodError: undefined method 'jbuilder'`
- Replace with `Jbuilder.prettify = true if defined?(Jbuilder)` which sets it directly on the class

## Test plan
- [ ] Render deploy passes `db:migrate` without crashing
- [ ] JSON responses are still prettified

🤖 Generated with [Claude Code](https://claude.com/claude-code)