### PR TITLE
Strip unused Rails engines for API-only deploy

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,15 +1,9 @@
 require File.expand_path('../boot', __FILE__)
 
 require "active_record/railtie"
-require "active_storage/engine"
 require "action_controller/railtie"
-require "action_mailer/railtie"
-require "action_mailbox/engine"
-require "action_text/engine"
 require "action_view/railtie"
-require "action_cable/engine"
 require "rails/test_unit/railtie"
-# require "sprockets/railtie" # Not needed for API-only app
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.


### PR DESCRIPTION
## Summary
- Remove active_storage, action_mailer, action_mailbox, action_text, and action_cable from application.rb
- Only load active_record, action_controller, action_view, and test_unit
- Active Storage was crashing deploy by requiring `secret_key_base` at boot time

## Test plan
- [ ] Render deploy passes
- [ ] `GET /diseases` returns JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)