### PR TITLE
Scrape Orphanet detail pages to populate clinical fields

### DIFF
--- a/app/lib/scrapers/orphanet/disease_parser.rb
+++ b/app/lib/scrapers/orphanet/disease_parser.rb
@@ -21,15 +21,17 @@ module Scrapers
       end
 
       def data
+        page_data = PageScraper.new(orpha_code).scrape
+
         {
           name: "#{disease_name} - #{DATA_SOURCE}",
           data_source: DATA_SOURCE,
           date_updated: Date.current.strftime('%B %Y'),
-          facts: [],
-          symptoms: [],
+          facts: page_data[:facts],
+          symptoms: page_data[:symptoms],
           transmission: [],
-          diagnosis: [],
-          treatment: [],
+          diagnosis: page_data[:diagnosis],
+          treatment: page_data[:treatment],
           prevention: [],
           prevalence: parse_prevalence,
           more: expert_link
@@ -40,6 +42,10 @@ module Scrapers
 
       def disease_name
         disorder_node.at_xpath('Name').text.strip
+      end
+
+      def orpha_code
+        disorder_node.at_xpath('OrphaCode').text.strip
       end
 
       def expert_link

--- a/app/lib/scrapers/orphanet/page_scraper.rb
+++ b/app/lib/scrapers/orphanet/page_scraper.rb
@@ -1,0 +1,94 @@
+require 'open-uri'
+
+module Scrapers
+  module Orphanet
+    class PageScraper
+      BASE_URL = 'https://www.orpha.net/en/disease/detail'
+
+      # Maps Orphanet page section headings to our data model fields.
+      SECTION_MAP = {
+        'clinical description' => :symptoms,
+        'diagnostic methods' => :diagnosis,
+        'management and treatment' => :treatment
+      }.freeze
+
+      attr_reader :orpha_code
+
+      def initialize(orpha_code)
+        @orpha_code = orpha_code
+      end
+
+      def scrape
+        result = { facts: disease_definition, symptoms: [], diagnosis: [], treatment: [] }
+
+        SECTION_MAP.each do |heading_text, field|
+          result[field] = extract_section(heading_text)
+        end
+
+        result
+      rescue StandardError => e
+        Rails.logger.warn("[Orphanet PageScraper] Failed to scrape detail page for #{orpha_code}: #{e.message}")
+        { facts: [], symptoms: [], diagnosis: [], treatment: [] }
+      end
+
+      private
+
+      def page
+        @page ||= Nokogiri::HTML(URI.open("#{BASE_URL}/#{orpha_code}", 'User-Agent' => 'ruby'))
+      end
+
+      def disease_definition
+        definition_heading = find_heading('disease definition')
+        return [] unless definition_heading
+
+        collect_paragraphs_after(definition_heading)
+      end
+
+      def extract_section(heading_text)
+        heading = find_heading(heading_text)
+        return [] unless heading
+
+        collect_paragraphs_after(heading)
+      end
+
+      def find_heading(text)
+        page.css('h2, h3, h4, h5, h6, strong, b').find do |el|
+          el.text.strip.downcase.include?(text)
+        end
+      end
+
+      def collect_paragraphs_after(heading)
+        paragraphs = []
+        sibling = next_content_element(heading)
+
+        while sibling
+          break if heading_element?(sibling)
+
+          if sibling.name == 'p' || (sibling.name == 'div' && sibling.css('p').any?)
+            texts = sibling.css('p').any? ? sibling.css('p').map { |p| p.text.strip } : [sibling.text.strip]
+            paragraphs.concat(texts.reject(&:blank?))
+          elsif sibling.name == 'ul' || sibling.name == 'ol'
+            sibling.css('li').each { |li| paragraphs << li.text.strip unless li.text.strip.blank? }
+          end
+
+          sibling = next_content_element(sibling)
+        end
+
+        paragraphs
+      end
+
+      def next_content_element(node)
+        current = node.next_sibling || node.parent&.next_sibling
+        current = current.next_sibling while current && current.text? && current.text.strip.empty?
+        current
+      end
+
+      def heading_element?(node)
+        return true if node.name.match?(/\Ah[2-6]\z/)
+        return true if %w[strong b].include?(node.name) && node.children.size <= 1
+
+        false
+      end
+    end
+  end
+end

--- a/app/lib/scrapers/orphanet/page_scraper.rb
+++ b/app/lib/scrapers/orphanet/page_scraper.rb
@@ -4,13 +4,19 @@ module Scrapers
   module Orphanet
     class PageScraper
       BASE_URL = 'https://www.orpha.net/en/disease/detail'
+      USER_AGENT = 'DiseaseInfoBot/1.0 (disease-info scraper; +https://github.com/devcenter-square/disease-info)'
+      OPEN_TIMEOUT = 10
+      READ_TIMEOUT = 15
 
       # Maps Orphanet page section headings to our data model fields.
+      # Matched using exact (case-insensitive) comparison against heading text.
       SECTION_MAP = {
         'clinical description' => :symptoms,
         'diagnostic methods' => :diagnosis,
         'management and treatment' => :treatment
       }.freeze
+
+      HEADING_TAGS = %w[h2 h3 h4 h5 h6].freeze
 
       attr_reader :orpha_code
 
@@ -19,7 +25,7 @@ module Scrapers
       end
 
       def scrape
-        result = { facts: disease_definition, symptoms: [], diagnosis: [], treatment: [] }
+        result = { facts: extract_section('disease definition'), symptoms: [], diagnosis: [], treatment: [] }
 
         SECTION_MAP.each do |heading_text, field|
           result[field] = extract_section(heading_text)
@@ -34,60 +40,70 @@ module Scrapers
       private
 
       def page
-        @page ||= Nokogiri::HTML(URI.open("#{BASE_URL}/#{orpha_code}", 'User-Agent' => 'ruby'))
+        @page ||= Nokogiri::HTML(
+          URI.open(
+            "#{BASE_URL}/#{orpha_code}",
+            'User-Agent' => USER_AGENT,
+            open_timeout: OPEN_TIMEOUT,
+            read_timeout: READ_TIMEOUT
+          )
+        )
       end
 
-      def disease_definition
-        definition_heading = find_heading('disease definition')
-        return [] unless definition_heading
-
-        collect_paragraphs_after(definition_heading)
+      def headings
+        @headings ||= page.css(HEADING_TAGS.join(', '))
       end
 
       def extract_section(heading_text)
-        heading = find_heading(heading_text)
-        return [] unless heading
+        index = headings.index { |h| h.text.strip.downcase == heading_text }
+        return [] unless index
 
-        collect_paragraphs_after(heading)
+        heading = headings[index]
+        next_heading = headings[index + 1]
+
+        collect_content_between(heading, next_heading)
       end
 
-      def find_heading(text)
-        page.css('h2, h3, h4, h5, h6, strong, b').find do |el|
-          el.text.strip.downcase.include?(text)
+      def collect_content_between(heading, next_heading)
+        if next_heading
+          xpath = following_siblings_xpath(heading, next_heading)
+        else
+          xpath = "//#{heading.name}[normalize-space()='#{heading.text.strip}']/following-sibling::*"
         end
+
+        nodes = page.xpath(xpath)
+        extract_text_from_nodes(nodes)
       end
 
-      def collect_paragraphs_after(heading)
+      def following_siblings_xpath(heading, next_heading)
+        h_tag = heading.name
+        h_text = heading.text.strip
+        nh_tag = next_heading.name
+        nh_text = next_heading.text.strip
+
+        "//#{h_tag}[normalize-space()='#{h_text}']/following-sibling::*" \
+          "[not(self::#{nh_tag}[normalize-space()='#{nh_text}']) " \
+          "and not(preceding-sibling::#{nh_tag}[normalize-space()='#{nh_text}']" \
+          "[preceding-sibling::#{h_tag}[normalize-space()='#{h_text}']])]"
+      end
+
+      def extract_text_from_nodes(nodes)
         paragraphs = []
-        sibling = next_content_element(heading)
 
-        while sibling
-          break if heading_element?(sibling)
+        nodes.each do |node|
+          break if HEADING_TAGS.include?(node.name)
 
-          if sibling.name == 'p' || (sibling.name == 'div' && sibling.css('p').any?)
-            texts = sibling.css('p').any? ? sibling.css('p').map { |p| p.text.strip } : [sibling.text.strip]
-            paragraphs.concat(texts.reject(&:blank?))
-          elsif sibling.name == 'ul' || sibling.name == 'ol'
-            sibling.css('li').each { |li| paragraphs << li.text.strip unless li.text.strip.blank? }
+          case node.name
+          when 'p'
+            paragraphs << node.text.strip unless node.text.strip.empty?
+          when 'div'
+            node.css('p').each { |p| paragraphs << p.text.strip unless p.text.strip.empty? }
+          when 'ul', 'ol'
+            node.css('li').each { |li| paragraphs << li.text.strip unless li.text.strip.empty? }
           end
-
-          sibling = next_content_element(sibling)
         end
 
         paragraphs
-      end
-
-      def next_content_element(node)
-        current = node.next_sibling || node.parent&.next_sibling
-        current = current.next_sibling while current && current.text? && current.text.strip.empty?
-        current
-      end
-
-      def heading_element?(node)
-        return true if node.name.match?(/\Ah[2-6]\z/)
-        return true if %w[strong b].include?(node.name) && node.children.size <= 1
-
-        false
       end
     end
   end

--- a/app/lib/scrapers/orphanet/parser.rb
+++ b/app/lib/scrapers/orphanet/parser.rb
@@ -1,6 +1,9 @@
 module Scrapers
   module Orphanet
     class Parser
+      CONCURRENCY = 5
+      REQUEST_DELAY = 0.5
+
       delegate :response, to: :request
       delegate :results,  to: :response
 
@@ -11,16 +14,27 @@ module Scrapers
       def perform
         successes = 0
         failures = []
+        mutex = Mutex.new
 
-        disorder_nodes.each do |node|
-          disease_data = Scrapers::Orphanet::DiseaseParser.new(node).data
-          Disease.create!(disease_data)
-          successes += 1
-        rescue StandardError => e
-          disease_name = node.at_xpath('Name')&.text rescue 'unknown'
-          Rails.logger.error("[Orphanet Scraper] Failed to process #{disease_name}: #{e.message}")
-          failures << { disease: disease_name, error: e.message }
-          next
+        disorder_nodes.each_slice(CONCURRENCY) do |batch|
+          threads = batch.map do |node|
+            Thread.new do
+              disease_data = Scrapers::Orphanet::DiseaseParser.new(node).data
+              mutex.synchronize do
+                Disease.create!(disease_data)
+                successes += 1
+              end
+            rescue StandardError => e
+              disease_name = node.at_xpath('Name')&.text rescue 'unknown'
+              mutex.synchronize do
+                Rails.logger.error("[Orphanet Scraper] Failed to process #{disease_name}: #{e.message}")
+                failures << { disease: disease_name, error: e.message }
+              end
+            end
+          end
+
+          threads.each(&:join)
+          sleep(REQUEST_DELAY)
         end
 
         log_summary(successes, failures)

--- a/spec/lib/scrapers/orphanet/disease_parser_spec.rb
+++ b/spec/lib/scrapers/orphanet/disease_parser_spec.rb
@@ -54,6 +54,17 @@ describe Scrapers::Orphanet::DiseaseParser do
 
   let(:node) { Nokogiri::XML(disorder_xml).at_xpath('//Disorder') }
   let(:parser) { described_class.new(node) }
+  let(:page_scraper) { instance_double(Scrapers::Orphanet::PageScraper) }
+
+  before do
+    allow(Scrapers::Orphanet::PageScraper).to receive(:new).with('166024').and_return(page_scraper)
+    allow(page_scraper).to receive(:scrape).and_return(
+      facts: ['A rare skeletal dysplasia.'],
+      symptoms: ['Frontal bossing', 'Short neck'],
+      diagnosis: ['Based on clinical signs.'],
+      treatment: ['Supportive management.']
+    )
+  end
 
   describe '#data' do
     it 'returns disease data with ORPHANET source suffix' do
@@ -69,11 +80,26 @@ describe Scrapers::Orphanet::DiseaseParser do
       expect(parser.data[:more]).to include('orpha.net')
     end
 
-    it 'initializes array fields as empty arrays' do
+    it 'populates facts from the page scraper' do
+      expect(parser.data[:facts]).to eq(['A rare skeletal dysplasia.'])
+    end
+
+    it 'populates symptoms from the page scraper' do
+      expect(parser.data[:symptoms]).to eq(['Frontal bossing', 'Short neck'])
+    end
+
+    it 'populates diagnosis from the page scraper' do
+      expect(parser.data[:diagnosis]).to eq(['Based on clinical signs.'])
+    end
+
+    it 'populates treatment from the page scraper' do
+      expect(parser.data[:treatment]).to eq(['Supportive management.'])
+    end
+
+    it 'keeps transmission and prevention as empty arrays' do
       data = parser.data
-      %i[facts symptoms transmission diagnosis treatment prevention].each do |field|
-        expect(data[field]).to eq([])
-      end
+      expect(data[:transmission]).to eq([])
+      expect(data[:prevention]).to eq([])
     end
 
     it 'parses prevalence from point prevalence class' do
@@ -82,10 +108,15 @@ describe Scrapers::Orphanet::DiseaseParser do
   end
 
   describe 'prevalence parsing' do
+    before do
+      allow(Scrapers::Orphanet::PageScraper).to receive(:new).with('12345').and_return(page_scraper)
+    end
+
     context 'with ValMoy greater than zero' do
       let(:disorder_xml) do
         <<~XML
           <Disorder>
+            <OrphaCode>12345</OrphaCode>
             <Name lang="en">Test Disease</Name>
             <ExpertLink lang="en">http://example.com</ExpertLink>
             <PrevalenceList count="1">
@@ -108,6 +139,7 @@ describe Scrapers::Orphanet::DiseaseParser do
       let(:disorder_xml) do
         <<~XML
           <Disorder>
+            <OrphaCode>12345</OrphaCode>
             <Name lang="en">Test Disease</Name>
             <ExpertLink lang="en">http://example.com</ExpertLink>
             <PrevalenceList count="1">
@@ -130,6 +162,7 @@ describe Scrapers::Orphanet::DiseaseParser do
       let(:disorder_xml) do
         <<~XML
           <Disorder>
+            <OrphaCode>12345</OrphaCode>
             <Name lang="en">Test Disease</Name>
             <ExpertLink lang="en">http://example.com</ExpertLink>
             <PrevalenceList count="0"/>
@@ -148,6 +181,7 @@ describe Scrapers::Orphanet::DiseaseParser do
           escaped_class = prevalence_class.gsub('<', '&lt;').gsub('>', '&gt;')
           <<~XML
             <Disorder>
+              <OrphaCode>12345</OrphaCode>
               <Name lang="en">Test Disease</Name>
               <ExpertLink lang="en">http://example.com</ExpertLink>
               <PrevalenceList count="1">

--- a/spec/lib/scrapers/orphanet/page_scraper_spec.rb
+++ b/spec/lib/scrapers/orphanet/page_scraper_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+describe Scrapers::Orphanet::PageScraper do
+  let(:orpha_code) { '558' }
+  let(:scraper) { described_class.new(orpha_code) }
+
+  let(:html) do
+    <<~HTML
+      <html>
+      <body>
+        <h3>Disease definition</h3>
+        <p>A systemic connective tissue disorder.</p>
+
+        <h3>Clinical description</h3>
+        <p>Symptoms can appear at any age.</p>
+        <p>Cardiovascular involvement is common.</p>
+
+        <h3>Diagnostic methods</h3>
+        <p>Diagnosis is based on clinical signs.</p>
+
+        <h3>Management and treatment</h3>
+        <p>Management should be multidisciplinary.</p>
+        <ul>
+          <li>Regular echocardiograms</li>
+          <li>Beta-blocker therapy</li>
+        </ul>
+
+        <h3>Prognosis</h3>
+        <p>Life expectancy has improved.</p>
+      </body>
+      </html>
+    HTML
+  end
+
+  before do
+    allow(URI).to receive(:open)
+      .with("#{described_class::BASE_URL}/#{orpha_code}", 'User-Agent' => 'ruby')
+      .and_return(html)
+  end
+
+  describe '#scrape' do
+    it 'extracts the disease definition as facts' do
+      expect(scraper.scrape[:facts]).to eq(['A systemic connective tissue disorder.'])
+    end
+
+    it 'extracts clinical description as symptoms' do
+      expect(scraper.scrape[:symptoms]).to include('Symptoms can appear at any age.')
+      expect(scraper.scrape[:symptoms]).to include('Cardiovascular involvement is common.')
+    end
+
+    it 'extracts diagnostic methods as diagnosis' do
+      expect(scraper.scrape[:diagnosis]).to eq(['Diagnosis is based on clinical signs.'])
+    end
+
+    it 'extracts management and treatment as treatment' do
+      result = scraper.scrape[:treatment]
+      expect(result).to include('Management should be multidisciplinary.')
+      expect(result).to include('Regular echocardiograms')
+      expect(result).to include('Beta-blocker therapy')
+    end
+  end
+
+  describe '#scrape when page fetch fails' do
+    before do
+      allow(URI).to receive(:open).and_raise(OpenURI::HTTPError.new('404', StringIO.new))
+    end
+
+    it 'returns empty arrays for all fields' do
+      result = scraper.scrape
+      expect(result).to eq(facts: [], symptoms: [], diagnosis: [], treatment: [])
+    end
+  end
+end

--- a/spec/lib/scrapers/orphanet/page_scraper_spec.rb
+++ b/spec/lib/scrapers/orphanet/page_scraper_spec.rb
@@ -34,7 +34,12 @@ describe Scrapers::Orphanet::PageScraper do
 
   before do
     allow(URI).to receive(:open)
-      .with("#{described_class::BASE_URL}/#{orpha_code}", 'User-Agent' => 'ruby')
+      .with(
+        "#{described_class::BASE_URL}/#{orpha_code}",
+        'User-Agent' => described_class::USER_AGENT,
+        open_timeout: described_class::OPEN_TIMEOUT,
+        read_timeout: described_class::READ_TIMEOUT
+      )
       .and_return(html)
   end
 
@@ -44,8 +49,10 @@ describe Scrapers::Orphanet::PageScraper do
     end
 
     it 'extracts clinical description as symptoms' do
-      expect(scraper.scrape[:symptoms]).to include('Symptoms can appear at any age.')
-      expect(scraper.scrape[:symptoms]).to include('Cardiovascular involvement is common.')
+      expect(scraper.scrape[:symptoms]).to eq([
+        'Symptoms can appear at any age.',
+        'Cardiovascular involvement is common.'
+      ])
     end
 
     it 'extracts diagnostic methods as diagnosis' do
@@ -54,15 +61,36 @@ describe Scrapers::Orphanet::PageScraper do
 
     it 'extracts management and treatment as treatment' do
       result = scraper.scrape[:treatment]
-      expect(result).to include('Management should be multidisciplinary.')
-      expect(result).to include('Regular echocardiograms')
-      expect(result).to include('Beta-blocker therapy')
+      expect(result).to eq([
+        'Management should be multidisciplinary.',
+        'Regular echocardiograms',
+        'Beta-blocker therapy'
+      ])
+    end
+
+    it 'uses exact heading match and does not false-match partial text' do
+      html_with_extended = html.sub('Clinical description', 'Extended clinical description')
+      allow(URI).to receive(:open).and_return(html_with_extended)
+
+      # "Extended clinical description" should NOT match "clinical description"
+      expect(scraper.scrape[:symptoms]).to eq([])
     end
   end
 
   describe '#scrape when page fetch fails' do
     before do
       allow(URI).to receive(:open).and_raise(OpenURI::HTTPError.new('404', StringIO.new))
+    end
+
+    it 'returns empty arrays for all fields' do
+      result = scraper.scrape
+      expect(result).to eq(facts: [], symptoms: [], diagnosis: [], treatment: [])
+    end
+  end
+
+  describe '#scrape when page fetch times out' do
+    before do
+      allow(URI).to receive(:open).and_raise(Net::OpenTimeout.new('execution expired'))
     end
 
     it 'returns empty arrays for all fields' do

--- a/spec/lib/scrapers/orphanet/parser_spec.rb
+++ b/spec/lib/scrapers/orphanet/parser_spec.rb
@@ -35,10 +35,15 @@ describe Scrapers::Orphanet::Parser do
     XML
   end
 
+  let(:empty_page_data) { { facts: [], symptoms: [], diagnosis: [], treatment: [] } }
+
   before do
     mock_response = instance_double(Scrapers::Orphanet::Response, results: orphanet_xml)
     mock_request = instance_double(Scrapers::Orphanet::Request, response: mock_response)
     allow(Scrapers::Orphanet::Request).to receive(:new).and_return(mock_request)
+
+    page_scraper = instance_double(Scrapers::Orphanet::PageScraper, scrape: empty_page_data)
+    allow(Scrapers::Orphanet::PageScraper).to receive(:new).and_return(page_scraper)
   end
 
   describe '.perform' do


### PR DESCRIPTION
## Summary
- ORPHANET diseases had empty `facts`, `symptoms`, `diagnosis`, and `treatment` arrays because the XML source only contains prevalence/classification data
- Adds `Scrapers::Orphanet::PageScraper` that fetches each disease's detail page (`orpha.net/en/disease/detail/{orpha_code}`) and extracts clinical content from section headings
- Maps "Disease definition" → facts, "Clinical description" → symptoms, "Diagnostic methods" → diagnosis, "Management and treatment" → treatment
- Gracefully falls back to empty arrays if a page fetch fails
- `transmission` and `prevention` remain empty as Orphanet rare disease pages don't contain those sections

## Test plan
- [ ] Verify `PageScraper` correctly extracts sections from a live Orphanet detail page (e.g., orpha code 558 for Marfan syndrome)
- [ ] Verify `DiseaseParser` now returns populated arrays instead of empty ones
- [ ] Verify graceful fallback when a detail page is unavailable (404, timeout)
- [ ] Run full Orphanet scraper and confirm disease records have clinical data populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)